### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,9 @@ name: Validate
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/simono/dotfiles/security/code-scanning/1](https://github.com/simono/dotfiles/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block for the workflow or for each job so that the `GITHUB_TOKEN` is limited to the minimal required scopes. For this workflow, the job only needs to read the repository contents to check out code; it does not perform any write operations on GitHub resources, so `contents: read` is sufficient.

The best minimal, non-breaking fix is to add a `permissions` block at the workflow root (top level), directly under the `name:` (or before `jobs:`). This will apply to all jobs in the workflow that do not define their own `permissions`. Specifically, in `.github/workflows/validate.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` clause and the `jobs:` block. No additional methods, imports, or definitions are required; this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
